### PR TITLE
throw unknown state if no data is returned or url has errors

### DIFF
--- a/check_graphite_data
+++ b/check_graphite_data
@@ -33,9 +33,17 @@ def pull_graphite_data(url):
     # Make sure the url ends with '&rawData'
     if not url.endswith('&rawData'):
         url = url + '&rawData'
-    data = urllib.urlopen(url).read()
-    return data
 
+    # Catch URL errors
+    try:
+	data = urllib.urlopen(url).read()
+	if len(data) == 0:
+	    print "Error: No data was returned. Did you specify an existing metric? - " + url
+	    sys.exit(STATE_UNKNOWN)
+	return data
+    except Exception,e:
+	print "Error: "+ str(e) +" - " + url
+        sys.exit(STATE_UNKNOWN)
 
 def eval_graphite_data(data, seconds):
     """Get the most recent correct value from the data"""


### PR DESCRIPTION
If a metric does not exist or the URL has error, the check exists with errocode 1 , putting it in warning state. This pull request fixes it to return the unknown state to show it correctly in nagios.

FYI: The way I noticed is was that the status information was set to 'null' and the service got into a warning state. This was due to an incorrect use of a variable in nagios.
