### PR TITLE
add --scale option so user can provide context for numbers

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,6 @@ Options:
     -L --critlower              Lower Holt-Winters band breach causes a crit,
                                     - breaching upper band causes a warn
     (If neither -U nor -L are given, we will always warn)
+    --scale=<multiplier>        scale, eg 8 to treat bytes as bits
+    --scale-invert=<divisor>    scale, eg 1073741824 to treat bytes as GiB
+                                    - --scale{-invert} lets you give thresholds in sane units

--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Options:
                                     - breaching lower band causes a warn
     -L --critlower              Lower Holt-Winters band breach causes a crit,
                                     - breaching upper band causes a warn
-    (If neither -U nor -L are given, we will always warn)
+    (If -W, but neither -U nor -L are given, we will always warn)
     --scale=<multiplier>        scale, eg 8 to treat bytes as bits
     --scale-invert=<divisor>    scale, eg 1073741824 to treat bytes as GiB
                                     - --scale{-invert} lets you give thresholds in sane units

--- a/check_graphite_data
+++ b/check_graphite_data
@@ -26,6 +26,9 @@ def usage():
     print '\t-L --critlower\t\t\tLower Holt-Winters band breach causes a crit,'
     print '\t\t\t\t\t- breaching upper band causes a warn'
     print '\t(If neither -U nor -L are given, we will always warn)'
+    print '\t--scale=<multiplier>\t\tscale, eg 8 to treat bytes as bits'
+    print '\t--scale-invert=<divisor>\tscale, eg 1073741824 to treat bytes as GiB'
+    print '\t\t\t\t\t- --scale{-invert} lets you give thresholds in sane units'
 
 
 def pull_graphite_data(url):
@@ -96,7 +99,9 @@ def main(argv):
         opts, args = getopt.getopt(argv, 'hWULru:c:w:s:',
                                     ['help', 'holt-winters', 'critupper',
                                      'critlower', 'url=', 'crit=', 'warn=',
-                                     'seconds=', 'd1=', 'd2='])
+                                     'seconds=', 'd1=', 'd2='
+				     ,'scale=' ,'scale-invert='
+				     ])
     except getopt.GetoptError, err:
         print str(err)
         sys.exit(STATE_UNKNOWN)
@@ -111,6 +116,7 @@ def main(argv):
     hw = None
     critupper = None
     critlower = None
+    scale = 1
     for opt, arg in opts:
         if opt in ('-h', '--help'):
             usage()
@@ -135,6 +141,10 @@ def main(argv):
             critupper = True
         elif opt in ('-L', '--critlower'):
             critlower = True
+        elif opt in ('--scale'):
+            scale = float(arg)
+        elif opt in ('--scale-invert'):
+            scale = 1 / float(arg)
     if not hw and ((url == None) or (warn == None) or (crit == None)) \
             and not diff1 and not diff2:
         usage()
@@ -161,6 +171,7 @@ def main(argv):
         graphite_data = abs(graphite_data1 - graphite_data2)
     else:
         graphite_data = get_value(url, seconds)
+    graphite_data *= scale
 
     print 'Current value: %s, warn threshold: %s, crit threshold: %s' % \
            (graphite_data, warn, crit)

--- a/check_graphite_data
+++ b/check_graphite_data
@@ -25,7 +25,7 @@ def usage():
     print '\t\t\t\t\t- breaching lower band causes a warn'
     print '\t-L --critlower\t\t\tLower Holt-Winters band breach causes a crit,'
     print '\t\t\t\t\t- breaching upper band causes a warn'
-    print '\t(If neither -U nor -L are given, we will always warn)'
+    print '\t(If -W, but neither -U nor -L are given, we will always warn)'
     print '\t--scale=<multiplier>\t\tscale, eg 8 to treat bytes as bits'
     print '\t--scale-invert=<divisor>\tscale, eg 1073741824 to treat bytes as GiB'
     print '\t\t\t\t\t- --scale{-invert} lets you give thresholds in sane units'


### PR DESCRIPTION
This lets the user specify thresholds for example in GiB instead of bytes.

It adds both --scale and --scale-invert.  For example, --scale=8 would let the user specify in bits rather than bytes, while --scale-invert=1073741824 would let the user specify in GiB rather than bytes.


There's also a clarification of Usage in the last commit of the series.