### PR TITLE
Avoid `eval` and fix logic errors.

### DIFF
--- a/check_graphite_data
+++ b/check_graphite_data
@@ -49,12 +49,7 @@ def eval_graphite_data(data, seconds):
     # If that data point is None, grab the one before it.
     # If that is None too, return 0.0.
     if seconds <= sample_period:
-        if eval(all_data_points[-1]):
-            data_value = float(all_data_points[-1])
-        elif eval(all_data_points[-2]):
-            data_value = float(all_data_points[-2])
-        else:
-            data_value = 0.0
+        data_value = ([ float(x) for x in all_data_points[-2:] if x != "None" ] or [0.0])[-1]
     else:
     # Second, if we requested more than on graphite sample period, work out how
     # many sample periods we wanted (python always rounds division *down*)

--- a/check_graphite_data
+++ b/check_graphite_data
@@ -55,7 +55,7 @@ def eval_graphite_data(data, seconds):
     # many sample periods we wanted (python always rounds division *down*)
         data_points = (seconds/sample_period)
         data_set = [ float(x) for x in all_data_points[-data_points:]
-                     if eval(x) ]
+                     if x != "None" ]
         if data_set:
             data_value = float( sum(data_set) / len(data_set) )
         else:


### PR DESCRIPTION
Similar to #4, with the added benefit of fewer `eval` calls.
