### PR TITLE
don't skip 0.0 values and don't eval()

### DIFF
--- a/check_graphite_data
+++ b/check_graphite_data
@@ -49,9 +49,9 @@ def eval_graphite_data(data, seconds):
     # If that data point is None, grab the one before it.
     # If that is None too, return 0.0.
     if seconds <= sample_period:
-        if eval(all_data_points[-1]):
+        if all_data_points[-1] != "None":
             data_value = float(all_data_points[-1])
-        elif eval(all_data_points[-2]):
+        elif all_data_points[-2] != "None":
             data_value = float(all_data_points[-2])
         else:
             data_value = 0.0
@@ -60,7 +60,7 @@ def eval_graphite_data(data, seconds):
     # many sample periods we wanted (python always rounds division *down*)
         data_points = (seconds/sample_period)
         data_set = [ float(x) for x in all_data_points[-data_points:]
-                     if eval(x) ]
+                     if x != "None" ]
         if data_set:
             data_value = float( sum(data_set) / len(data_set) )
         else:

--- a/check_graphite_data
+++ b/check_graphite_data
@@ -49,9 +49,9 @@ def eval_graphite_data(data, seconds):
     # If that data point is None, grab the one before it.
     # If that is None too, return 0.0.
     if seconds <= sample_period:
-        if all_data_points[-1] != "None":
+        if not all_data_points[-1].startswith("None"):
             data_value = float(all_data_points[-1])
-        elif all_data_points[-2] != "None":
+        elif not all_data_points[-2].startswith("None"):
             data_value = float(all_data_points[-2])
         else:
             data_value = 0.0
@@ -60,7 +60,7 @@ def eval_graphite_data(data, seconds):
     # many sample periods we wanted (python always rounds division *down*)
         data_points = (seconds/sample_period)
         data_set = [ float(x) for x in all_data_points[-data_points:]
-                     if x != "None" ]
+                     if not x.startswith("None") ]
         if data_set:
             data_value = float( sum(data_set) / len(data_set) )
         else:


### PR DESCRIPTION
Similar to @whilp's #5, but hewing closer to the original 
if-else logic instead of a -1 array index, and addressing
a bug I found where graphite sometimes returns "None\n",
which gets past the strict != "None" test.

Details:

Previously we were testing boolean status of eval'd
values retrieved from graphite, which has two
potential problems:

1) eval() is potentially dangerous; if someone is able
   to coax the graphite webserver into returning
   code strings, they'll be happily executed.

2) By checking strictly for boolean truthiness, we end
   up skipping all zero values; this is less an issue
   when seconds <= sample_period, but can drastically
   skew the averaging logic.

This should fix, and seems to stick to the original intent
given the comments preceding the if seconds <= sample_period
block.
